### PR TITLE
Make sure the compilation uses conda's compiler

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
+declare -a CMAKE_PLATFORM_FLAGS
+if [[ -n "${OSX_ARCH}" ]]; then
+    CMAKE_PLATFORM_FLAGS+=(-DCMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}")
+else
+    CMAKE_PLATFORM_FLAGS+=(-DCMAKE_TOOLCHAIN_FILE="${RECIPE_DIR}/cross-linux.cmake")
+fi
+
 mkdir build
 cd build
 
 cmake \
     -DCMAKE_PREFIX_PATH=${PREFIX} \
     -DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} \
-    -DBUILD_SHARED_LIBS=on ..
+    -DBUILD_SHARED_LIBS=on \
+    ${CMAKE_PLATFORM_FLAGS[@]} \
+    ..
 
 make CCfits
 

--- a/recipe/cross-linux.cmake
+++ b/recipe/cross-linux.cmake
@@ -1,0 +1,21 @@
+# this one is important
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_PLATFORM Linux)
+#this one not so much
+set(CMAKE_SYSTEM_VERSION 1)
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER $ENV{CC})
+set(CMAKE_CXX_COMPILER $ENV{CXX})
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH $ENV{PREFIX} $ENV{BUILD_PREFIX}/$ENV{HOST}/sysroot)
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# god-awful hack because it seems to not run correct tests to determine this:
+set(__CHAR_UNSIGNED___EXITCODE 1)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1000
+  number: 1001
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hello,

It looks like CCfits is being compiled with the system's compiler rather than conda's one, which makes impossible to link software that does use conda's compiler, as the std::string API differs between one and the other.

Looking at meta.yaml, it seems like the intention is to use conda's one, so I have followed the [suggestions from conda's documentation](https://conda.io/projects/conda-build/en/latest/resources/compiler-tools.html#an-aside-on-cmake-and-sysroots).